### PR TITLE
task/errors hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "bundlesize": [
     {
       "path": "./dist/main.min.js",
-      "maxSize": "11 kB",
+      "maxSize": "12 kB",
       "compression": "none"
     },
     {

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@
  - [Install](#install)
  - [Introduction](#Introduction)
  - [Handler Lifecycle](#Handler-lifecycle)
+ - [Error Handling](#Error-handling)
  - [Plugins](#plugins)
  - [Creating a Plugin](#creating-a-plugin)
  - [Using a Plugin](#using-a-plugin)
@@ -140,6 +141,40 @@ The lifecycle provides a clear guideline to reason about your needs. Every step 
 <p align="center">
 <img src="https://raw.githubusercontent.com/juliantellez/lambcycle/master/assets/lifecycle.svg?sanitize=true" height=500>
 </p>
+
+# Error Handling
+As you can see from the lifecycle graph above, the error object is a first class citizen that will stop the cycle and execute any error plugins declared in the register, it will then proceed to call the lambda handler's callback.
+Have a look at the [Wrapper Interface](https://github.com/juliantellez/lambcycle/blob/master/src/Interfaces/IWrapper.ts) to see what's available for reporting.
+
+`HINT: pretty much everything.`
+
+```javascript
+import lambcycle from 'lambcycle'
+import notifyError from './myErrorNofifier'
+
+const appLogic = async(event, context) => {
+    const {error, data} = await amazingJob()
+    if(error) {
+        throw error
+    }
+}
+
+const errorNotifier = {
+    plugin: {
+        onError: async (handler) => {
+            /**
+             * See IWrapper interface
+            */
+            await notifyError(handler.error)
+        }
+    }
+}
+
+const handler = lambcycle(appLogic).register([errorNotifier])
+
+export default handler;
+```
+
 
 # Plugins
 

--- a/src/Constants/PluginType.ts
+++ b/src/Constants/PluginType.ts
@@ -1,0 +1,5 @@
+enum PluginType {
+    ERROR = 'PLUGIN_TYPE_ERROR'
+}
+
+export default PluginType;

--- a/src/Helpers/exectueHandler.test.ts
+++ b/src/Helpers/exectueHandler.test.ts
@@ -7,7 +7,7 @@ import randomTimeout from '../Utils/randomTimeout';
 
 import executeHandler from './executeHandler';
 
-describe('executeHandler', () => {
+describe('ExecuteHandler', () => {
     it('should support async handlers', async () => {
         const handleError = () => null;
         const response = {

--- a/src/Helpers/executeHandler.ts
+++ b/src/Helpers/executeHandler.ts
@@ -9,6 +9,8 @@ const executeHandler = async (
     wrapper: IWrapper,
     handleError: Callback
 ) => {
+    if (wrapper.error) return;
+
     const addResponseToWrapper = (response: any) => {
         wrapper.response = response;
     };

--- a/src/Helpers/executePlugins.ts
+++ b/src/Helpers/executePlugins.ts
@@ -1,5 +1,6 @@
 import { Callback } from 'aws-lambda';
 
+import PluginType from '../Constants/PluginType';
 import IWrapper from '../Interfaces/IWrapper';
 
 import executePlugin from './executePlugin';
@@ -7,9 +8,12 @@ import executePlugin from './executePlugin';
 const executePlugins = async (
     lifeCyclePlugins: any[],
     wrapper: IWrapper,
-    handleError: Callback
+    handleError: Callback,
+    pluginType?: string
 ) => {
     for (const index in lifeCyclePlugins) {
+        if (pluginType !== PluginType.ERROR && wrapper.error) return;
+
         await executePlugin(lifeCyclePlugins[index], wrapper, handleError);
     }
 };

--- a/src/Plugins/BodyParser/Utils/toLowerCaseShallow.test.ts
+++ b/src/Plugins/BodyParser/Utils/toLowerCaseShallow.test.ts
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 
 import toLowerCaseShallow from './toLowerCaseShallow';
 
-describe('toLowerCaseShallow', () => {
+describe('ToLowerCaseShallow', () => {
     it('should reduce obj to lowercase', () => {
         const obj = {
             FOO: 'BAZ',

--- a/src/Utils/callOnce.test.ts
+++ b/src/Utils/callOnce.test.ts
@@ -1,0 +1,37 @@
+import { assert } from 'chai';
+
+import callOnce from './callOnce';
+
+describe('callOnce', () => {
+    it('should call the supplied function once', () => {
+        let counter = 0;
+        const fn = () => (counter += 1);
+
+        const wrappedFunction = callOnce(fn);
+
+        wrappedFunction();
+        wrappedFunction();
+
+        const value = counter;
+        const expected = 1;
+
+        assert.equal(value, expected);
+    });
+
+    it('should pass arguments from wrapper', () => {
+        let addition = 0;
+        const add = (arg1: number, arg2: number) => {
+            addition = arg1 + arg2;
+        };
+
+        const wrappedFunction = callOnce(add);
+
+        wrappedFunction(10, 20);
+        wrappedFunction(100, 200);
+
+        const value = addition;
+        const expected = 30;
+
+        assert.equal(value, expected);
+    });
+});

--- a/src/Utils/callOnce.ts
+++ b/src/Utils/callOnce.ts
@@ -1,0 +1,13 @@
+const callOnce = (fn: (...args: any[]) => any) => {
+    let called = false;
+
+    return (...args: any[]) => {
+        if (called) return;
+
+        called = true;
+
+        return fn.apply(null, args);
+    };
+};
+
+export default callOnce;

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -8,8 +8,8 @@ import contextMock from './Mocks/Lambda/Context';
 import customError from './Utils/customError';
 import randomTimeout from './Utils/randomTimeout';
 
-describe('middleware', () => {
-    describe('wrapper', () => {
+describe('Middleware', () => {
+    describe('Wrapper', () => {
         it('should create a handler wrapper', () => {
             const funcHandler = () => void 0;
 
@@ -20,23 +20,86 @@ describe('middleware', () => {
             assert.property(wrapper, 'register');
         });
 
-        it('should be able to register plugin functions', () => {
-            const funcHandler = () => void 0;
+        it('should accept a callback type lambdaHandler', async () => {
+            const handlerResponse = {
+                foo: 'baz'
+            };
+            const funcHandler: ILambdaHandler = (_, __, callback) => {
+                callback(null, handlerResponse);
+            };
 
-            const wrapper = lambcycle(funcHandler).register([
-                {
-                    plugin: {
-                        onRequest: () => null
-                    }
-                }
-            ]);
+            const wrapper = lambcycle(funcHandler);
 
-            const value = wrapper.plugins.onRequest;
-            const expected = 1;
+            await wrapper({}, contextMock, (_, response) => {
+                const value = response;
+                const expected = handlerResponse;
 
-            assert.lengthOf(value, expected);
+                assert.deepEqual(value, expected);
+            });
         });
 
+        it('should accept a async type lambdaHandler', async () => {
+            const handlerResponse = {
+                foo: 'baz'
+            };
+            const funcHandler = async () => {
+                return await randomTimeout().then(() => handlerResponse);
+            };
+
+            const wrapper = lambcycle(funcHandler);
+
+            await wrapper({}, contextMock, (_, response) => {
+                const value = response;
+                const expected = handlerResponse;
+
+                assert.deepEqual(value, expected);
+            });
+        });
+
+        it('should accept a promise type lambdaHandler', async () => {
+            const handlerResponse = {
+                foo: 'baz'
+            };
+            const funcHandler = () => {
+                return randomTimeout().then(() => handlerResponse);
+            };
+
+            const wrapper = lambcycle(funcHandler);
+
+            await wrapper({}, contextMock, (_, response) => {
+                const value = response;
+                const expected = handlerResponse;
+
+                assert.deepEqual(value, expected);
+            });
+        });
+
+        it('should accept a sync type lambdaHandler', async () => {
+            /**
+             * NB:
+             * Sync handlers should not return undefined!
+             * the handler will interpret undefined as a callback type handler
+             * and your function may stall for a long time!!
+             */
+
+            const handlerResponse = {
+                foo: 'baz'
+            };
+
+            const funcHandler = () => handlerResponse;
+
+            const wrapper = lambcycle(funcHandler);
+
+            await wrapper({}, contextMock, (_, response) => {
+                const value = response;
+                const expected = handlerResponse;
+
+                assert.deepEqual(value, expected);
+            });
+        });
+    });
+
+    describe('Plugins', () => {
         it('should be able to pass configuration to plugins declaratively', () => {
             const funcHandler = () => void 0;
 
@@ -200,265 +263,317 @@ describe('middleware', () => {
                 assert.deepEqual(value, expected);
             });
         });
+    });
 
-        it('should allow plugins to invoke the error handler', async () => {
-            const pluginError = new Error('foo');
+    describe('Register', () => {
+        it('should be able to register plugins', () => {
+            const funcHandler = () => void 0;
 
-            const pluginManifest = {
-                plugin: {
-                    onRequest: (_, __, handleError: Callback) => {
-                        handleError(pluginError);
+            const wrapper = lambcycle(funcHandler).register([
+                {
+                    plugin: {
+                        onRequest: () => null
                     }
                 }
-            };
+            ]);
 
-            const funcHandler = () => null;
-            const wrapper = lambcycle(funcHandler).register([pluginManifest]);
+            const value = wrapper.plugins.onRequest;
+            const expected = 1;
 
-            await wrapper({}, contextMock, error => {
-                const value = error;
-                const expected = pluginError;
-                assert.deepEqual(value, expected);
-            });
-        });
-
-        it('should pass errors to error plugins', async () => {
-            const errorValue = [customError('foo'), customError('baz')];
-
-            const errorExpected: Error[] = [];
-
-            const pluginManifest = {
-                plugin: {
-                    onPreHandler: () => {
-                        return randomTimeout(10)
-                            .then(() => randomTimeout(10))
-                            .then(() => {
-                                throw errorValue[0];
-                            });
-                    },
-                    onPostHandler: async () => {
-                        await randomTimeout(20);
-                        throw errorValue[1];
-                    },
-                    onError: async (innerWrapper: IWrapper) => {
-                        await randomTimeout();
-                        errorExpected.push(innerWrapper.error);
-                    }
-                }
-            };
-
-            const funcHandler = () => null;
-            const wrapper = lambcycle(funcHandler).register([pluginManifest]);
-
-            await wrapper({}, contextMock, () => {
-                const value = errorValue;
-                const expected = errorExpected;
-
-                assert.deepEqual(value, expected);
-                assert.deepEqual(errorValue, errorExpected);
-            });
-        });
-
-        it('should accept a callback type lambdaHandler', async () => {
-            const handlerResponse = {
-                foo: 'baz'
-            };
-            const funcHandler: ILambdaHandler = (_, __, callback) => {
-                callback(null, handlerResponse);
-            };
-
-            const wrapper = lambcycle(funcHandler);
-
-            await wrapper({}, contextMock, (_, response) => {
-                const value = response;
-                const expected = handlerResponse;
-
-                assert.deepEqual(value, expected);
-            });
-        });
-
-        it('should accept a async type lambdaHandler', async () => {
-            const handlerResponse = {
-                foo: 'baz'
-            };
-            const funcHandler = async () => {
-                return await randomTimeout().then(() => handlerResponse);
-            };
-
-            const wrapper = lambcycle(funcHandler);
-
-            await wrapper({}, contextMock, (_, response) => {
-                const value = response;
-                const expected = handlerResponse;
-
-                assert.deepEqual(value, expected);
-            });
-        });
-
-        it('should accept a promise type lambdaHandler', async () => {
-            const handlerResponse = {
-                foo: 'baz'
-            };
-            const funcHandler = () => {
-                return randomTimeout().then(() => handlerResponse);
-            };
-
-            const wrapper = lambcycle(funcHandler);
-
-            await wrapper({}, contextMock, (_, response) => {
-                const value = response;
-                const expected = handlerResponse;
-
-                assert.deepEqual(value, expected);
-            });
-        });
-
-        it('should accept a sync type lambdaHandler', async () => {
-            const handlerResponse = {
-                foo: 'baz'
-            };
-
-            const funcHandler = () => handlerResponse;
-
-            const wrapper = lambcycle(funcHandler);
-
-            await wrapper({}, contextMock, (_, response) => {
-                const value = response;
-                const expected = handlerResponse;
-
-                assert.deepEqual(value, expected);
-            });
-        });
-
-        it('should catch async errors in handler', async () => {
-            const handlerError = customError('foo');
-            const funcHandler = async () => {
-                return await randomTimeout().then(() => {
-                    throw handlerError;
-                });
-            };
-
-            const wrapper = lambcycle(funcHandler);
-
-            await wrapper({}, contextMock, error => {
-                const value = error;
-                const expected = handlerError;
-
-                assert.deepEqual(value, expected);
-            });
-        });
-
-        it('should catch promise errors in handler', async () => {
-            const handlerError = customError('foo');
-            const funcHandler = () => {
-                return randomTimeout(100).then(() => {
-                    throw handlerError;
-                });
-            };
-
-            const wrapper = lambcycle(funcHandler);
-
-            await wrapper({}, contextMock, error => {
-                const value = error;
-                const expected = handlerError;
-
-                assert.deepEqual(value, expected);
-            });
-        });
-
-        it('should catch callback errors in handler', async () => {
-            const handlerError = customError('foo');
-            const funcHandler = (_, __, callback) => {
-                callback(handlerError);
-            };
-
-            const wrapper = lambcycle(funcHandler);
-
-            await wrapper({}, contextMock, error => {
-                const value = error;
-                const expected = handlerError;
-
-                assert.deepEqual(value, expected);
-            });
-        });
-
-        it('should catch sync errors in handler', async () => {
-            const handlerError = customError('foo');
-            const funcHandler = () => {
-                throw handlerError;
-            };
-
-            const wrapper = lambcycle(funcHandler);
-
-            await wrapper({}, contextMock, error => {
-                const value = error;
-                const expected = handlerError;
-
-                assert.deepEqual(value, expected);
-            });
-        });
-
-        it('should handle handler errors asynchronously', async () => {
-            const handlerError = customError('foo');
-
-            const errorHandlers: string[] = [];
-            const reporter = {
-                plugin: {
-                    onError: async () => {
-                        await randomTimeout();
-                        errorHandlers.push('reporter');
-                    }
-                }
-            };
-
-            const logger = {
-                plugin: {
-                    onError: async () => {
-                        await randomTimeout();
-                        errorHandlers.push('logger');
-                    }
-                }
-            };
-
-            const funcHandler = () => {
-                throw handlerError;
-            };
-            const wrapper = lambcycle(funcHandler).register([reporter, logger]);
-
-            await wrapper({}, contextMock, () => {
-                const value = errorHandlers;
-                const expected = ['reporter', 'logger'];
-
-                assert.deepEqual(value, expected);
-            });
+            assert.lengthOf(value, expected);
         });
     });
 
-    describe('register', () => {
-        it('should throw if no plugin is supplied', () => {
-            const funcHandler = () => null;
+    describe('Errors', () => {
+        describe('Wrapper', () => {
+            it('should catch async errors in handler', async () => {
+                const handlerError = customError('foo');
+                const funcHandler = async () => {
+                    return await randomTimeout().then(() => {
+                        throw handlerError;
+                    });
+                };
 
-            assert.throws(() => lambcycle(funcHandler).register([]));
+                const wrapper = lambcycle(funcHandler);
+
+                await wrapper({}, contextMock, error => {
+                    const value = error;
+                    const expected = handlerError;
+
+                    assert.deepEqual(value, expected);
+                });
+            });
+
+            it('should catch promise errors in handler', async () => {
+                const handlerError = customError('foo');
+                const funcHandler = () => {
+                    return randomTimeout(100).then(() => {
+                        throw handlerError;
+                    });
+                };
+
+                const wrapper = lambcycle(funcHandler);
+
+                await wrapper({}, contextMock, error => {
+                    const value = error;
+                    const expected = handlerError;
+
+                    assert.deepEqual(value, expected);
+                });
+            });
+
+            it('should catch callback errors in handler', async () => {
+                const handlerError = customError('foo');
+                const funcHandler = (_, __, callback) => {
+                    callback(handlerError);
+                };
+
+                const wrapper = lambcycle(funcHandler);
+
+                await wrapper({}, contextMock, error => {
+                    const value = error;
+                    const expected = handlerError;
+
+                    assert.deepEqual(value, expected);
+                });
+            });
+
+            it('should catch sync errors in handler', async () => {
+                const handlerError = customError('foo');
+                const funcHandler = () => {
+                    throw handlerError;
+                };
+
+                const wrapper = lambcycle(funcHandler);
+
+                await wrapper({}, contextMock, error => {
+                    const value = error;
+                    const expected = handlerError;
+
+                    assert.deepEqual(value, expected);
+                });
+            });
+
+            it('should handle handler errors asynchronously', async () => {
+                const handlerError = customError('foo');
+
+                const errorHandlers: string[] = [];
+                const reporter = {
+                    plugin: {
+                        onError: async () => {
+                            await randomTimeout();
+                            errorHandlers.push('reporter');
+                        }
+                    }
+                };
+
+                const logger = {
+                    plugin: {
+                        onError: async () => {
+                            await randomTimeout();
+                            errorHandlers.push('logger');
+                        }
+                    }
+                };
+
+                const funcHandler = () => {
+                    throw handlerError;
+                };
+
+                const wrapper = lambcycle(funcHandler).register([
+                    reporter,
+                    logger
+                ]);
+
+                await wrapper({}, contextMock, () => {
+                    const value = errorHandlers;
+                    const expected = ['reporter', 'logger'];
+
+                    assert.deepEqual(value, expected);
+                });
+            });
+
+            it('should call the lambdaCallback only once', async () => {
+                const error = customError('a');
+
+                const pluginManifest = {
+                    plugin: {
+                        onPreHandler: () => {
+                            return randomTimeout(10)
+                                .then(() => randomTimeout(10))
+                                .then(() => {
+                                    throw customError('a');
+                                });
+                        },
+                        onPostHandler: async () => {
+                            await randomTimeout(20);
+                            throw customError('b');
+                        }
+                    }
+                };
+
+                const funcHandler = () => {
+                    throw customError('c');
+                };
+
+                const wrapper = lambcycle(funcHandler).register([
+                    pluginManifest
+                ]);
+
+                let counter = 0;
+                await wrapper({}, contextMock, e => {
+                    counter += 1;
+
+                    const value = counter;
+                    const expected = 1;
+
+                    assert.deepEqual(value, expected);
+                });
+            });
+
+            it('should call errorHandler plugins only once', async () => {
+                let counter = 0;
+
+                const asyncPlugin = {
+                    plugin: {
+                        onPreHandler: () => {
+                            return randomTimeout(10)
+                                .then(() => randomTimeout(10))
+                                .then(() => {
+                                    throw customError('a');
+                                });
+                        }
+                    }
+                };
+
+                const errorPlugin = {
+                    plugin: {
+                        onError: async () => {
+                            await randomTimeout(20);
+                            counter += 1;
+                        }
+                    }
+                };
+
+                const loggerPlugin = {
+                    plugin: {
+                        onError: async () => {
+                            await randomTimeout(20);
+                            counter += 1;
+                        }
+                    }
+                };
+
+                const funcHandler = () => {
+                    throw customError('c');
+                };
+
+                const wrapper = lambcycle(funcHandler).register([
+                    asyncPlugin,
+                    errorPlugin,
+                    loggerPlugin
+                ]);
+
+                await wrapper({}, contextMock, e => {
+                    const value = counter;
+                    const expected = 2;
+
+                    assert.deepEqual(value, expected);
+                });
+            });
         });
-        it('should throw if plugin hook does not exist', () => {
-            const funcHandler = () => null;
 
-            const logger = {
-                plugin: {}
-            };
+        describe('Plugins', () => {
+            it('should allow plugins to invoke the handleError callback', async () => {
+                const pluginError = new Error('foo');
 
-            assert.throws(() => lambcycle(funcHandler).register([logger]));
+                const pluginManifest = {
+                    plugin: {
+                        onRequest: (_, __, handleError: Callback) => {
+                            handleError(pluginError);
+                        }
+                    }
+                };
+
+                const funcHandler = () => null;
+                const wrapper = lambcycle(funcHandler).register([
+                    pluginManifest
+                ]);
+
+                await wrapper({}, contextMock, error => {
+                    const value = error;
+                    const expected = pluginError;
+                    assert.deepEqual(value, expected);
+                });
+            });
+
+            it('should pass errors to error plugins', async () => {
+                const errorValue = [customError('foo'), customError('baz')];
+
+                const errorExpected: Error[] = [];
+
+                const pluginManifest = {
+                    plugin: {
+                        onPreHandler: () => {
+                            return randomTimeout(10)
+                                .then(() => randomTimeout(10))
+                                .then(() => {
+                                    throw errorValue[0];
+                                });
+                        },
+                        onPostHandler: async () => {
+                            await randomTimeout(20);
+                            throw errorValue[1];
+                        },
+                        onError: async (innerWrapper: IWrapper) => {
+                            await randomTimeout();
+                            errorExpected.push(innerWrapper.error);
+                        }
+                    }
+                };
+
+                const funcHandler = () => null;
+                const wrapper = lambcycle(funcHandler).register([
+                    pluginManifest
+                ]);
+
+                await wrapper({}, contextMock, () => {
+                    const value = errorValue[0];
+                    const expected = errorExpected[0];
+
+                    assert.deepEqual(value, expected);
+                });
+            });
         });
-        it('should throw if plugin hook name is invalid', () => {
-            const funcHandler = () => null;
 
-            const logger = {
-                plugin: {}
-            };
+        describe('Register', () => {
+            it('should throw if no plugin is supplied', () => {
+                const funcHandler = () => null;
 
-            logger.plugin['foo'] = () => null;
+                assert.throws(() => lambcycle(funcHandler).register([]));
+            });
 
-            assert.throws(() => lambcycle(funcHandler).register([logger]));
+            it('should throw if plugin hook does not exist', () => {
+                const funcHandler = () => null;
+
+                const logger = {
+                    plugin: {}
+                };
+
+                assert.throws(() => lambcycle(funcHandler).register([logger]));
+            });
+
+            it('should throw if plugin hook name is invalid', () => {
+                const funcHandler = () => null;
+
+                const logger = {
+                    plugin: {}
+                };
+
+                logger.plugin['foo'] = () => null;
+
+                assert.throws(() => lambcycle(funcHandler).register([logger]));
+            });
         });
     });
 });


### PR DESCRIPTION
#  Error Handling
The error object is a first class citizen that will stop the cycle and execute any error plugins declared in the register, it will then proceed to call the lambda handler's callback.
Have a look at the [Wrapper Interface](https://github.com/juliantellez/lambcycle/blob/master/src/Interfaces/IWrapper.ts) to see what's available for reporting.
`HINT: pretty much everything.`
```javascript
import lambcycle from 'lambcycle'
import notifyError from './myErrorNofifier'
const appLogic = async(event, context) => {
    const {error, data} = await amazingJob()
    if(error) {
        throw error
    }
}
const errorNotifier = {
    plugin: {
        onError: async (handler) => {
            /**
             * See IWrapper interface
            */
            await notifyError(handler.error)
        }
    }
}
const handler = lambcycle(appLogic).register([errorNotifier])
export default handler;
```

<!-- E.g. a bug fix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
yes
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

<img src="https://raw.githubusercontent.com/juliantellez/lambcycle/master/assets/lambcycle-logo.svg?sanitize=true" height="200">
@juliantellez
